### PR TITLE
Update from `embassy-traits` (deprecated?) to `embedded-hal-async`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ out_f32 = [
 ] # enables normalised floating point output
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
+
 accelerometer = "0.12.0"
 num-traits = { version = "0.2.19", optional = true, default-features = false }
 num-derive = { version = "0.4.2", optional = true, default-features = false }
-embedded-hal-async = { version = "1.0.0", optional = true }
-nb = "1.1.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lis2dw12"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["David Haig <david@ninjametal.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/ninjasource/lis2dw12"
@@ -9,25 +9,23 @@ description = "A no_std compatible Rust driver for the low power ST 3-Axis MEMS 
 readme = "README.md"
 keywords = ["accelerometer", "sensor", "spi", "driver", "no_std"]
 categories = ["embedded", "no-std"]
-edition = "2018"
+edition = "2021"
 
 [features]
-default = ["non_blocking"]
-non_blocking = ["embassy-traits"] # enables async, requires Nightly. Experimental.
-out_f32 = ["num-traits", "num-derive"] # enables normalised floating point output
+default = ["non_blocking", "out_f32"]
+non_blocking = ["dep:embedded-hal-async"]
+out_f32 = [
+    "dep:num-traits",
+    "dep:num-derive",
+] # enables normalised floating point output
 
 [dependencies]
 embedded-hal = "0.2.5"
 accelerometer = "0.12.0"
-num-traits = { version = "0.2.14", optional = true, default-features = false }
-num-derive = { version = "0.3.3", optional = true, default-features = false }
-# embassy-traits = { version = "0.0.2", optional = true, features = ["defmt"]}
-embassy-traits = { version = "0.1.0", git = "https://github.com/embassy-rs/embassy", optional = true, features = ["defmt"]}
-nb = { version = "1.0" }
-
-# [patch.crates-io]
-# embassy-traits = { version = "0.1.0", git = "https://github.com/embassy-rs/embassy" }
+num-traits = { version = "0.2.19", optional = true, default-features = false }
+num-derive = { version = "0.4.2", optional = true, default-features = false }
+embedded-hal-async = { version = "1.0.0", optional = true }
+nb = "1.1.0"
 
 [profile.release]
 lto = true
-

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,0 @@
-# NOTE: You only need to use the nightly toolchain when the "non_blocking" feature is enabled
-
-[toolchain]
-# channel = "stable"
-channel = "nightly-2021-05-07"

--- a/src/non_blocking.rs
+++ b/src/non_blocking.rs
@@ -1,10 +1,10 @@
 use crate::*;
 use accelerometer::vector::I16x3;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 use embedded_hal_async::spi::SpiDevice;
 
 #[cfg(feature = "out_f32")]
-pub use accelerometer::{vector::F32x3, Accelerometer};
+pub use accelerometer::vector::F32x3;
 
 impl<SPI, SpiError, CS, PinError> Lis2dw12<SPI, CS>
 where

--- a/src/non_blocking.rs
+++ b/src/non_blocking.rs
@@ -1,14 +1,14 @@
 use crate::*;
 use accelerometer::vector::I16x3;
-use embassy_traits::spi::FullDuplex;
 use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_async::spi::SpiDevice;
 
 #[cfg(feature = "out_f32")]
 pub use accelerometer::{vector::F32x3, Accelerometer};
 
 impl<SPI, SpiError, CS, PinError> Lis2dw12<SPI, CS>
 where
-    SPI: FullDuplex<u8, Error = SpiError>,
+    SPI: SpiDevice<Error = SpiError>,
     CS: OutputPin<Error = PinError>,
 {
     pub async fn check_who_am_i(&mut self) -> Result<(), Error<SpiError, PinError>> {


### PR DESCRIPTION
Update from `embassy-traits` (deprecated?) to `embedded-hal-async` (v1.0)

Support rust stable and update some deps
Bump version to v0.2.0

Haven't tested (as Í dont have the hardware using a SPI bus), but does compile again. Non blocking support available on stable Rust from v1.75.

I'm planning to add I2C support (probably will be a breaking change) and embedded-hal v1 support, so stay tuned for that. 